### PR TITLE
Turn off lines-between class members & prefer default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
   rules: {
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     '@typescript-eslint/comma-dangle': ['error', 'never'],
+    '@typescript-eslint/lines-between-class-members': 'off',
     '@typescript-eslint/no-use-before-define': [
       'error',
       {
@@ -28,6 +29,7 @@ module.exports = {
     ],
     'class-methods-use-this': 'off',
     'func-names': 'off',
+    'import/prefer-default-export': 'off',
     'linebreak-style': 'off',
     'lines-between-class-members': 'off',
     'max-len': ['error', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-surikat",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-surikat",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-surikat",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Surikat's way of coding in TS",
   "author": "Surikat <npm@surikat.se>",
   "license": "MIT",


### PR DESCRIPTION
**Turn off lines-between-class-members**
This also gives a warning when there are no blank lines between property declarations in TS classes. TypeScript ESLint even recommends [turning this (and all formatting rules) off](https://typescript-eslint.io/rules/lines-between-class-members) in order to let a dedicated formatter decide that.

![image](https://user-images.githubusercontent.com/22885176/205905125-57557b19-810f-4df7-81b4-9dc78aa374df.png)

**Turn of import/prefer-default-export**
If a module is exporting more than one thing (e.g. an interface and a class), this will not warn. If the interface is later moved, it complains that a default export should be preferred. It does not make sense to have to update whether it's a default export depending on how many files it's exporting. It's also more convenient a lot of times to use named exports. E.g. when exporting re-exporting several things from an `index` file, we can simply do `export * from './thing'` instead of `export { default as thing } from './thing'.

![image](https://user-images.githubusercontent.com/22885176/205905197-d1bb9ccf-7a89-41e7-a98e-de826a185ced.png)

![image](https://user-images.githubusercontent.com/22885176/205905293-31ef7f25-100d-466a-b349-c646ddb71504.png)
