### PR TITLE
Disable some rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     '@typescript-eslint/comma-dangle': ['error', 'never'],
     '@typescript-eslint/lines-between-class-members': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-use-before-define': [
       'error',
       {
@@ -38,11 +39,13 @@ module.exports = {
     }],
     'no-continue': 'off',
     'no-multi-spaces': ['warn', { exceptions: { VariableDeclarator: true } }],
+    'no-param-reassign': 'off',
     'no-plusplus': 'off',
     'no-underscore-dangle': 'off',
     'object-curly-newline': 'off',
     'prefer-destructuring': 'off',
-    'prefer-object-spread': 'off'
+    'prefer-object-spread': 'off',
+    'promise/no-promise-in-callback': 'off'
   },
   'overrides': [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-surikat",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-surikat",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-surikat",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Surikat's way of coding in TS",
   "author": "Surikat <npm@surikat.se>",
   "license": "MIT",


### PR DESCRIPTION
[@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/)
There are cases where it's necessary to specify any, and `unknown` will not suffice. In general, `any` should be avoided, but I think it's a bit too strict to enforce it in all places, leading to a lot of unnecessary time spent somewhere where it doesn't really matter. There are active rules putting restrictions on variables with type `any` such as `no-unsafe-member-access` and `no-unsafe-call`.

[no-param-reassign](https://eslint.org/docs/latest/rules/no-param-reassign)
There are cases where re-assigning parameters are helpful. E.g. to extract a piece of logic that might be duplicated, when the sole purpose of the function is to modify the parameter. Since we're not coding in a purely functional manner, this rule does not make too much sense.

[promise/no-promise-in-callback](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-promise-in-callback.md)
We should be allowed to call promises from inside e.g. forEach loop callbacks. The rule is not motivated in the rule's documentation.