### PR TITLE
Enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
   rules: {
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     '@typescript-eslint/comma-dangle': ['error', 'never'],
+    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/lines-between-class-members': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-use-before-define': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-surikat",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-surikat",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-surikat",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Surikat's way of coding in TS",
   "author": "Surikat <npm@surikat.se>",
   "license": "MIT",


### PR DESCRIPTION
Using the default value of separate-type-imports, since inline-type-imports requires TypeScript 4.5 or above